### PR TITLE
Update Advanced Achievements hook

### DIFF
--- a/PlanPluginBridge/pom.xml
+++ b/PlanPluginBridge/pom.xml
@@ -69,6 +69,10 @@
             <id>placeholderapi</id>
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>advanced-achievements-repo</id>
+            <url>https://raw.github.com/PyvesB/AdvancedAchievements/mvn-repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -94,9 +98,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.hm</groupId>
-            <artifactId>advanced.achievements</artifactId>
-            <version>5.2</version>
+            <groupId>com.hm.achievement</groupId>
+            <artifactId>advanced-achievements-api</artifactId>
+            <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/PlanPluginBridge/src/main/java/com/djrapitops/pluginbridge/plan/advancedachievements/AdvancedAchievementsHook.java
+++ b/PlanPluginBridge/src/main/java/com/djrapitops/pluginbridge/plan/advancedachievements/AdvancedAchievementsHook.java
@@ -2,11 +2,10 @@ package com.djrapitops.pluginbridge.plan.advancedachievements;
 
 import com.djrapitops.plan.data.plugin.HookHandler;
 import com.djrapitops.pluginbridge.plan.Hook;
-import com.hm.achievement.AdvancedAchievements;
 import com.hm.achievement.api.AdvancedAchievementsAPI;
-import com.hm.achievement.api.AdvancedAchievementsBukkitAPI;
+import com.hm.achievement.api.AdvancedAchievementsAPIFetcher;
 
-import static org.bukkit.plugin.java.JavaPlugin.getPlugin;
+import java.util.Optional;
 
 /**
  * A Class responsible for hooking to AdvancedAchievements and registering 2
@@ -29,12 +28,12 @@ public class AdvancedAchievementsHook extends Hook {
         super("com.hm.achievement.AdvancedAchievements", hookH);
     }
 
-    public void hook() throws NoClassDefFoundError {
+    @Override
+	public void hook() throws NoClassDefFoundError {
         if (enabled) {
-            AdvancedAchievements aa = getPlugin(AdvancedAchievements.class);
-            if (Integer.parseInt(Character.toString(aa.getDescription().getVersion().charAt(0))) >= 5) {
-                AdvancedAchievementsAPI aaAPI = AdvancedAchievementsBukkitAPI.linkAdvancedAchievements();
-                addPluginDataSource(new AdvancedAchievementsData(aaAPI));
+            Optional<AdvancedAchievementsAPI> aaAPI = AdvancedAchievementsAPIFetcher.fetchInstance();
+            if (aaAPI.isPresent()) {
+                addPluginDataSource(new AdvancedAchievementsData(aaAPI.get()));
             } else {
                 enabled = false;
             }

--- a/PlanPluginBridge/src/main/java/com/djrapitops/pluginbridge/plan/advancedachievements/AdvancedAchievementsHook.java
+++ b/PlanPluginBridge/src/main/java/com/djrapitops/pluginbridge/plan/advancedachievements/AdvancedAchievementsHook.java
@@ -29,7 +29,7 @@ public class AdvancedAchievementsHook extends Hook {
     }
 
     @Override
-	public void hook() throws NoClassDefFoundError {
+    public void hook() throws NoClassDefFoundError {
         if (enabled) {
             Optional<AdvancedAchievementsAPI> aaAPI = AdvancedAchievementsAPIFetcher.fetchInstance();
             if (aaAPI.isPresent()) {


### PR DESCRIPTION
Hello there!

This pull request updates the Advanced Achievements hook to use the new standalone API artifact. Note that doing so will only work with plugin versions 5.8.0 onwards, so you'll have to warn users in the update changelog. I could implement a workaround for the hook to work with 5.7.0+, but that will add quite a bit of code inside _AdvancedAchievementsHook_ (~15 lines). Let me know what you think!

Submitting the pull request to _master_ as there is no version specific branch yet. 😉 

Cheers,

Pyves