### PR TITLE
Fixed SLF4J startup warnings

### DIFF
--- a/Plan/pom.xml
+++ b/Plan/pom.xml
@@ -114,6 +114,12 @@
             <artifactId>HikariCP</artifactId>
             <version>3.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>1.7.25</version>
+            <scope>runtime</scope>
+        </dependency>
 
         <!--        Geo IP -->
         <dependency>

--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,4 @@
+DEV|4.4.7-b4|https://github.com/Rsl1122/Plan-PlayerAnalytics/releases/download/4.5.0-DEV4/Plan-4.4.7-b4-bukkit-bungee.jar|https://github.com/Rsl1122/Plan-PlayerAnalytics/releases/tag/4.5.0-DEV4
 REL|4.4.7|https://github.com/Rsl1122/Plan-PlayerAnalytics/releases/download/4.4.7-REL/Plan-4.4.7-bukkit-bungee.jar|https://github.com/Rsl1122/Plan-PlayerAnalytics/releases/tag/4.4.7-REL
 REL|4.4.6|https://github.com/Rsl1122/Plan-PlayerAnalytics/releases/download/4.4.6-REL/Plan-4.4.6-bukkit-bungee.jar|https://github.com/Rsl1122/Plan-PlayerAnalytics/releases/tag/4.4.6-REL
 DEV|4.4.5-b2|https://github.com/Rsl1122/Plan-PlayerAnalytics/releases/download/4.4.6-DEV2/Plan-4.4.5-b2-bukkit-bungee.jar|https://github.com/Rsl1122/Plan-PlayerAnalytics/releases/tag/4.4.6-DEV2


### PR DESCRIPTION
Hello there!

This pull request addresses #666. HikariCP relies on the SLF4J API for its logging, but you need to plug in an implementation (what SLF4J refers to as a "binding") at runtime for the logging to actually work.

I've selected the `slf4j-nop` as the implementation, in other words it suppresses the SLF4J logging, however other choices are also possible. 😉 

Cheers,

Pyves