### PR TITLE
Don't create dependency-reduced-pom

### DIFF
--- a/Plan/pom.xml
+++ b/Plan/pom.xml
@@ -323,6 +323,7 @@
                             <shadedPattern>com.djrapitops.plan.utilities.metrics</shadedPattern>
                         </relocation>
                     </relocations>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Since this plugin always generates one on compile, and since it's tracked in the git repo people have to revert their copy in order to pull changes.